### PR TITLE
Eliminate setting js/React before and after ns

### DIFF
--- a/resources/om-next.cljs
+++ b/resources/om-next.cljs
@@ -1,14 +1,9 @@
-;; Need to set js/React first so that Om can load
-(set! js/React (js/require "react-native/Libraries/react-native/react-native.js"))
-
 (ns $PROJECT_NAME_HYPHENATED$.core
   (:require [om.next :as om :refer-macros [defui]])
   (:require-macros [natal-shell.components :refer [view text image touchable-highlight]]
                    [natal-shell.alert-ios :refer [alert]]))
 
-;; Reset js/React back as the form above loads in a different React
 (set! js/React (js/require "react-native/Libraries/react-native/react-native.js"))
-
 
 (defonce app-state (atom {:app/msg "Welcome to $PROJECT_NAME$"}))
 

--- a/resources/om.cljs
+++ b/resources/om.cljs
@@ -1,14 +1,9 @@
-;; Need to set js/React first so that Om can load
-(set! js/React (js/require "react-native/Libraries/react-native/react-native.js"))
-
 (ns $PROJECT_NAME_HYPHENATED$.core
   (:require [om.core :as om])
   (:require-macros [natal-shell.components :refer [view text image touchable-highlight]]
                    [natal-shell.alert-ios :refer [alert]]))
 
-;; Reset js/React back as the form above loads in a different React
 (set! js/React (js/require "react-native/Libraries/react-native/react-native.js"))
-
 
 (defonce app-state (atom {:text "Welcome to $PROJECT_NAME$"}))
 


### PR DESCRIPTION
In the early days, the pattern of setting js/React
before loading Om and then re-setting it back
afterwards was necessary. This is evidently
not needed any longer and we can return to
what looks like a "normal" namespace structure.
