### PR TITLE
Eliminate init function

### DIFF
--- a/resources/AppDelegate.m
+++ b/resources/AppDelegate.m
@@ -225,10 +225,6 @@ RCT_EXPORT_MODULE()
   JSContext* context = [JSContext contextWithJSGlobalContextRef:self.contextManager.context];
   [self requireAppNamespaces:context];
 
-  JSValue* initFn = [self getValue:@"init" inNamespace:@"$PROJECT_NAME_HYPHENATED$.core" fromContext:context];
-  NSAssert(!initFn.isUndefined, @"Could not find the app init function");
-  [initFn callWithArguments:@[]];
-
   // Send a nonsense UI event to cause React Native to load our Om UI
   RCTRootView* rootView = (RCTRootView*)self.window.rootViewController.view;
   [rootView.bridge.modules[@"RCTEventDispatcher"] sendInputEventWithName:@"dummy" body:@{@"target": @1}];

--- a/resources/om-next.cljs
+++ b/resources/om-next.cljs
@@ -57,7 +57,3 @@
     :root-unmount #(.unmountComponentAtNode js/React %)}))
 
 (om/add-root! reconciler WidgetComponent 1)
-
-(defn ^:export init []
-  ((fn render []
-     (.requestAnimationFrame js/window render))))

--- a/resources/om.cljs
+++ b/resources/om.cljs
@@ -39,7 +39,3 @@
 
 
 (om/root widget app-state {:target 1})
-
-(defn ^:export init []
-  ((fn render []
-     (.requestAnimationFrame js/window render))))


### PR DESCRIPTION
With previous versons of React Native and Om,
it was necessary to set up a looping call to
requestAnimationFrame in order to get the iOS
UI to update automatically upon state or code
changes. (You'd have to click in the UI or
otherwise interact with it.) Now, this is
evidently no longer necessary.
